### PR TITLE
Updated width and positioning

### DIFF
--- a/public/assets/less/source/editor-controls.less
+++ b/public/assets/less/source/editor-controls.less
@@ -2,8 +2,9 @@
 // center controls containing the editor editor, settings, and add new post button
 .lasso--controls__center {
 
-    width:@control--width;
-    left: ~'calc(50% - @{control--width} / 2)';
+    width: auto;
+    left: 50%;
+    .translate(-50%, 0);
 
     li {
         list-style-type: none;
@@ -17,16 +18,14 @@
 
     }
     &.lasso--post-all-disabled {
-        @d-width: 34px;
-        width:@d-width;
-        left: ~'calc(50% - @{d-width} / 2)';
+
     }
 }
 
 .home .lasso--controls__center{
-    @width:66px;
-    width:@width;
-    left: ~'calc(50% - @{width} / 2)';
+    width: auto;
+    left: 50%;
+    .translate(-50%, 0);
 }
 
 // save and publish controls

--- a/public/assets/less/source/toolbar.less
+++ b/public/assets/less/source/toolbar.less
@@ -1,13 +1,12 @@
 // main toolbar layout
 .lasso--toolbar_wrap {
 
-    width:@toolbar--width;
-    left: ~'calc(50% - @{toolbar--width} / 2)';
+    width: auto;
+    left: 50%;
+    .translate(-50%, 0);
 
     &.toolbar-extended {
-        @width: 313px;
-        width:@width;
-        left: ~'calc(50% - @{width} / 2)';
+
     }
 
 }


### PR DESCRIPTION
Instead of statically defined widths (and having to use `calc()` to calculate centering), use this:

```
width: auto;
left: 50%;
transform: translate(-50%, 0);
```

Using vendor-prefixing for `transform`, of course.
