### PR TITLE
Enqueue Tour JS if needed

### DIFF
--- a/public/includes/assets.php
+++ b/public/includes/assets.php
@@ -188,7 +188,7 @@ class assets {
 			//enqueue js if tour is not hidden 
             		$tour_hidden = get_user_meta( get_current_user_ID(), 'lasso_hide_tour', true );
     			if ( lasso_user_can() && !$tour_hidden ){
-                		wp_enqueue_script('lasso', LASSO_URL. "/public/assets/js/tour.js", array('jquery', 'lasso'), LASSO_VERSION, true);
+                		wp_enqueue_script('lasso-tour', LASSO_URL. "/public/assets/js/tour.js", array('jquery', 'lasso'), LASSO_VERSION, true);
     			}
 
 		}

--- a/public/includes/assets.php
+++ b/public/includes/assets.php
@@ -184,7 +184,12 @@ class assets {
 			    wp_enqueue_script('lasso', LASSO_URL. "/public/assets/js/lasso{$postfix}.js", array('jquery'), LASSO_VERSION, true);
 			}
 			wp_localize_script('lasso', 'lasso_editor', apply_filters('lasso_localized_objects', $objects ) );
-
+			
+			//enqueue js if tour is not hidden 
+            		$tour_hidden = get_user_meta( get_current_user_ID(), 'lasso_hide_tour', true );
+    			if ( lasso_user_can() && !$tour_hidden ){
+                		wp_enqueue_script('lasso', LASSO_URL. "/public/assets/js/tour.js", array('jquery', 'lasso'), LASSO_VERSION, true);
+    			}
 
 		}
 


### PR DESCRIPTION
Use wp_enqueue_script instead of outputting the js.
Was triggering an undefined function JS error if 'lasso' was loaded
in footer
