### PR TITLE
Remove JS already enqueued if needed

### DIFF
--- a/public/includes/tour.php
+++ b/public/includes/tour.php
@@ -34,23 +34,6 @@ class tour {
 
 			?>
 			<div id="lasso--tour__modal" class="lasso--modal lasso--tour__modal lasso--modal__checkbox <?php echo sanitize_html_class( $custom_classes );?>">
-				<script>
-					(function( $ ) {
-						jQuery(document).ready(function($){
-
-							$('body').addClass('lasso-modal-open');
-
-							$('.lasso--loading').remove();
-							$('#lasso--tour__slides').hide().fadeIn()
-
-							$('#lasso--tour__slides').unslider({
-								dots: true,
-								delay:7000
-							});
-
-						});
-					})( jQuery );
-				</script>
 				<div class="lasso--modal__inner">
 
 					<?php echo self::tour_slides();?>


### PR DESCRIPTION
Use wp_enqueue_script instead of outputting the js.
Was triggering an undefined function JS error if 'lasso' was loaded
in footer
